### PR TITLE
Add OpenFoodFacts lookup after barcode scan

### DIFF
--- a/templates/add.html
+++ b/templates/add.html
@@ -79,6 +79,7 @@ btn.addEventListener('click', () => {
     document.getElementById('barcode').value = code;
     html5.stop();
     scanner.style.display = 'none';
+    fetchBarcodeInfo(code);
   }).catch(err => {console.error(err);});
 });
 
@@ -107,6 +108,35 @@ function getNutriScoreLetter(score) {
     return 'E';
   }
   return (score || '').toString().toUpperCase();
+}
+
+async function fetchBarcodeInfo(code) {
+  nameField.style.display = 'none';
+  summary.style.display = 'block';
+  loading.style.display = 'block';
+  try {
+    const resp = await fetch(`https://world.openfoodfacts.org/api/v0/product/${code}.json`);
+    const data = await resp.json();
+    const product = data.product;
+    if (!product) {
+      summary.textContent = 'Produit non reconnu, veuillez réessayer ou entrer manuellement.';
+      return;
+    }
+    const nutr = product.nutriments || {};
+    autoName.value = product.product_name || '';
+    autoCalories.value = nutr['energy-kcal_100g'] || '';
+    autoProtein.value = nutr['proteins_100g'] || '';
+    autoCarbs.value = nutr['carbohydrates_100g'] || '';
+    autoFat.value = nutr['fat_100g'] || '';
+    autoFiber.value = nutr['fiber_100g'] || '';
+    autoScore.value = getNutriScoreLetter(product.nutriscore_grade);
+    summary.textContent = `${autoName.value} - ${autoCalories.value} kcal/100g - Nutri-score ${autoScore.value}`;
+  } catch (err) {
+    console.error(err);
+    summary.textContent = 'Erreur lors du chargement du produit';
+  } finally {
+    loading.style.display = 'none';
+  }
 }
 photoBtn.addEventListener('click', () => {
   photoInput.click();


### PR DESCRIPTION
## Summary
- fetch product details from OpenFoodFacts when a barcode is scanned

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_684705ae74dc832e87643df0a7466cc4