### PR TITLE
Add persistent repeating timers with audio

### DIFF
--- a/src/timerWorker.ts
+++ b/src/timerWorker.ts
@@ -1,0 +1,13 @@
+let timeoutId: number | null = null;
+self.onmessage = (e: MessageEvent) => {
+  const { type, delay } = e.data as { type: string; delay?: number };
+  if (type === 'start' && typeof delay === 'number') {
+    clearTimeout(timeoutId as number);
+    timeoutId = setTimeout(() => {
+      self.postMessage({ type: 'expired' });
+    }, delay);
+  } else if (type === 'stop') {
+    clearTimeout(timeoutId as number);
+    timeoutId = null;
+  }
+};


### PR DESCRIPTION
## Summary
- introduce a Web Worker for timing
- persist timer settings and next alarm in localStorage
- restore timers on reload and play a beep sound
- replace binary alarm assets with Web Audio API

## Testing
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_b_6847639da6a8832eb051e80d72038989